### PR TITLE
Fixed issue with delta/rate metric

### DIFF
--- a/src/scalar_metrics.go
+++ b/src/scalar_metrics.go
@@ -31,7 +31,7 @@ func populateScalarMetrics(device string, metricSet metricSet, entity *integrati
 		return fmt.Errorf("Metric Set %s has %d metrics, the current limit is 200. This metric set will not be reported", metricSet.Name, len(oids))
 	}
 
-	ms := entity.NewMetricSet(metricSet.EventType)
+	ms := entity.NewMetricSet(metricSet.EventType, metric.Attr("IntegrationVersion", integrationVersion))
 	err := ms.SetMetric("device", device, metric.ATTRIBUTE)
 	if err != nil {
 		log.Error(err.Error())

--- a/src/table_metrics.go
+++ b/src/table_metrics.go
@@ -68,7 +68,7 @@ func populateTableMetrics(device string, metricSet metricSet, entity *integratio
 	}
 
 	for indexKey, indexNVPairs := range indexKeyMaps {
-		ms := entity.NewMetricSet(metricSet.EventType)
+		ms := entity.NewMetricSet(metricSet.EventType, metric.Attr("IntegrationVersion", integrationVersion))
 		err = ms.SetMetric("device", device, metric.ATTRIBUTE)
 		if err != nil {
 			log.Error(err.Error())


### PR DESCRIPTION
- Added "IntegrationVersion" attribute to allow delta and rate metrics to be attached.
It fixes the following error when having: **metric_type: delta** or **metric_type: rate**  types in the snmp-metric.yml file. 
[ERR] delta/rate metrics should be attached to an attribute identified metric-set