### PR TITLE
Implement Timeout, Retries and Backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.1 (2020-10-25)
+### Changed
+- Added Timeout, Retries and Exponential Timeout.
+
 ## 1.2.0 (2020-05-11)
 ### Changed
 - Update the gosnmp library version.

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -69,9 +69,8 @@ func createMetric(metricName string, metricType metric.SourceType, pdu gosnmp.Sn
 		boolValue := pdu.Value.(bool)
 		if boolValue {
 			return ms.SetMetric(metricName, 1, sourceType)
-		} else {
-			return ms.SetMetric(metricName, 0, sourceType)
 		}
+		return ms.SetMetric(metricName, 0, sourceType)
 	case gosnmp.BitString:
 		return fmt.Errorf("unsupported PDU type[BitString] for %v", metricName)
 	case gosnmp.TimeTicks:

--- a/src/snmp.go
+++ b/src/snmp.go
@@ -35,7 +35,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.snmp"
-	integrationVersion = "1.2.0"
+	integrationVersion = "1.2.1"
 )
 
 var (

--- a/src/snmp.go
+++ b/src/snmp.go
@@ -17,17 +17,20 @@ import (
 
 type argumentList struct {
 	sdkArgs.DefaultArgumentList
-	SNMPHost        string `default:"127.0.0.1" help:"Hostname or IP where the SNMP server is running."`
-	SNMPPort        int    `default:"161" help:"Port on which SNMP server is listening."`
-	Community       string `default:"public" help:"SNMP Version 2 Community string "`
-	V3              bool   `default:"false" help:"Use SNMP Version 3."`
-	SecurityLevel   string `default:"" help:"Valid values are noAuthnoPriv, authNoPriv or authPriv"`
-	Username        string `default:"" help:"The security name that identifies the SNMPv3 user."`
-	AuthProtocol    string `default:"SHA" help:"The algorithm used for SNMPv3 authentication (SHA or MD5)."`
-	AuthPassphrase  string `default:"" help:"The password used to generate the key used for SNMPv3 authentication."`
-	PrivProtocol    string `default:"AES" help:"The algorithm used for SNMPv3 message integrity."`
-	PrivPassphrase  string `default:"" help:"The password used to generate the key used to verify SNMPv3 message integrity."`
-	CollectionFiles string `default:"" help:"A comma separated list of full paths to metrics configuration files"`
+	SNMPHost           string `default:"127.0.0.1" help:"Hostname or IP where the SNMP server is running."`
+	SNMPPort           int    `default:"161" help:"Port on which SNMP server is listening."`
+	Timeout            int    `default:"10" help:"The number of seconds to wait before a request times out."`
+	Retries            int    `default:"0" help:"The number of attemps to fetch metrics."`
+	ExponentialTimeout bool   `default:"false" help:"Double timeout in each attempt."`
+	Community          string `default:"public" help:"SNMP Version 2 Community string "`
+	V3                 bool   `default:"false" help:"Use SNMP Version 3."`
+	SecurityLevel      string `default:"" help:"Valid values are noAuthnoPriv, authNoPriv or authPriv"`
+	Username           string `default:"" help:"The security name that identifies the SNMPv3 user."`
+	AuthProtocol       string `default:"SHA" help:"The algorithm used for SNMPv3 authentication (SHA or MD5)."`
+	AuthPassphrase     string `default:"" help:"The password used to generate the key used for SNMPv3 authentication."`
+	PrivProtocol       string `default:"AES" help:"The algorithm used for SNMPv3 message integrity."`
+	PrivPassphrase     string `default:"" help:"The password used to generate the key used to verify SNMPv3 message integrity."`
+	CollectionFiles    string `default:"" help:"A comma separated list of full paths to metrics configuration files"`
 }
 
 const (

--- a/src/util.go
+++ b/src/util.go
@@ -27,7 +27,9 @@ func connect(targetHost string, targetPort int) error {
 				Target:             targetHost,
 				Port:               uint16(targetPort),
 				Version:            gosnmp.Version3,
-				Timeout:            time.Duration(10) * time.Second,
+				Timeout:            time.Duration(uint16(args.Timeout)) * time.Second,
+				ExponentialTimeout: args.ExponentialTimeout,
+				Retries:            int(args.Retries),
 				SecurityModel:      gosnmp.UserSecurityModel,
 				MsgFlags:           msgFlags,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: args.Username},
@@ -47,12 +49,14 @@ func connect(targetHost string, targetPort int) error {
 				return fmt.Errorf("Must specify valid auth_protocol for SNMP v3 (valid values are SHA or MD5)")
 			}
 			theSNMP = &gosnmp.GoSNMP{
-				Target:        targetHost,
-				Port:          uint16(targetPort),
-				Version:       gosnmp.Version3,
-				Timeout:       time.Duration(10) * time.Second,
-				SecurityModel: gosnmp.UserSecurityModel,
-				MsgFlags:      msgFlags,
+				Target:             targetHost,
+				Port:               uint16(targetPort),
+				Version:            gosnmp.Version3,
+				Timeout:            time.Duration(uint16(args.Timeout)) * time.Second,
+				ExponentialTimeout: args.ExponentialTimeout,
+				Retries:            int(args.Retries),
+				SecurityModel:      gosnmp.UserSecurityModel,
+				MsgFlags:           msgFlags,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: args.Username,
 					AuthenticationProtocol:   authProtocol,
 					AuthenticationPassphrase: args.AuthPassphrase,
@@ -82,12 +86,14 @@ func connect(targetHost string, targetPort int) error {
 			}
 
 			theSNMP = &gosnmp.GoSNMP{
-				Target:        targetHost,
-				Port:          uint16(targetPort),
-				Version:       gosnmp.Version3,
-				Timeout:       time.Duration(10) * time.Second,
-				SecurityModel: gosnmp.UserSecurityModel,
-				MsgFlags:      msgFlags,
+				Target:             targetHost,
+				Port:               uint16(targetPort),
+				Version:            gosnmp.Version3,
+				Timeout:            time.Duration(uint16(args.Timeout)) * time.Second,
+				Retries:            int(args.Retries),
+				ExponentialTimeout: args.ExponentialTimeout,
+				SecurityModel:      gosnmp.UserSecurityModel,
+				MsgFlags:           msgFlags,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: args.Username,
 					AuthenticationProtocol:   authProtocol,
 					AuthenticationPassphrase: args.AuthPassphrase,
@@ -102,12 +108,14 @@ func connect(targetHost string, targetPort int) error {
 	} else {
 		community := strings.TrimSpace(args.Community)
 		theSNMP = &gosnmp.GoSNMP{
-			Target:    targetHost,
-			Port:      uint16(targetPort),
-			Version:   gosnmp.Version2c,
-			Community: community,
-			Timeout:   time.Duration(10 * time.Second), // Timeout better suited to walking
-			MaxOids:   8900,
+			Target:             targetHost,
+			Port:               uint16(targetPort),
+			Version:            gosnmp.Version2c,
+			Community:          community,
+			Timeout:            time.Duration(uint16(args.Timeout)) * time.Second, // Timeout better suited to walking
+			ExponentialTimeout: args.ExponentialTimeout,
+			Retries:            int(args.Retries),
+			MaxOids:            8900,
 		}
 	}
 

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -16,7 +16,7 @@ param (
 $integration = $(Split-Path -Leaf $PSScriptRoot)
 $integrationName = "snmp"
 $executable = "nri-snmp.exe"
-$version = "1.1.2"
+$version = "1.2.1"
 
 # verifying version number format
 $v = $version.Split(".")


### PR DESCRIPTION
Implemented Timeout (default 10 seconds as per previous value), # of Retries (default 0) and Exponential Timeout (default false) which double the time out value for each retry

Updated Changelog to version 1.2.1

This is to address request https://github.com/newrelic/nri-snmp/issues/24

Examples
./nri-snmp 
Uses default timeout of 10 seconds
Timeouts after **10** seconds

./nri-snmp -timeout 20
Uses timeout of **20** seconds
Timeouts after 20 seconds

./nri-snmp -timeout 5 -retries 1
Uses timeout of 5 seconds
Timeouts after **10** seconds
   1st call (5 seconds)
   1 retry (5 seconds)

./nri-snmp -timeout 5 -retries 2 -exponential_timeout true
Uses timeout of 5 seconds
Timeouts after **35** seconds
   1st call (5 seconds)
   1 retry (10 seconds)
   1 retry (20 seconds)