### PR TITLE
arvdias/add windows config path example

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -100,6 +100,7 @@ archives:
     files:
       - snmp-config.yml.sample
       - snmp-definition.yml
+      - snmp-metrics.yml.sample
     format: tar.gz
 
   - id: nri-win
@@ -109,6 +110,7 @@ archives:
     files:
       - snmp-config.yml.sample
       - snmp-win-definition.yml
+      - snmp-metrics.yml.sample
     format: zip
 
 # we use custom publisher for fixing archives and signing them

--- a/build/nix/fix_archives.sh
+++ b/build/nix/fix_archives.sh
@@ -25,6 +25,7 @@ find dist -regex ".*_dirty\.tar.gz" | while read tarball_dirty; do
   mv ${TARBALL_CONTENT_PATH}/nri-${INTEGRATION} "${TARBALL_CONTENT_PATH}/var/db/newrelic-infra/newrelic-integrations/bin/"
   mv ${TARBALL_CONTENT_PATH}/${INTEGRATION}-definition.yml ${TARBALL_CONTENT_PATH}/var/db/newrelic-infra/newrelic-integrations/
   mv ${TARBALL_CONTENT_PATH}/${INTEGRATION}-config.yml.sample ${TARBALL_CONTENT_PATH}/etc/newrelic-infra/integrations.d/
+  mv ${TARBALL_CONTENT_PATH}/${INTEGRATION}-metrics.yml.sample ${TARBALL_CONTENT_PATH}/etc/newrelic-infra/integrations.d/
 
   echo "===> Creating tarball ${TARBALL_CLEAN}"
   cd ${TARBALL_CONTENT_PATH}

--- a/build/package/windows/nri-386-installer/Product.wxs
+++ b/build/package/windows/nri-386-installer/Product.wxs
@@ -93,6 +93,12 @@
                       Source="$(var.BinariesPath)New Relic\newrelic-infra\integrations.d\$(var.IntegrationName)-config.yml.sample"
                       KeyPath="yes"/>
             </Component>
+            <Component Id="CMP_NRI_$(var.IntegrationName)_METRICS_YML" Guid="afbe3a0f-e7ac-4be0-9f47-2e2121ae08ca" Win64="no">
+                <File Id="FILE_NRI_$(var.IntegrationName)_METRICS_YML"
+                      Name="$(var.IntegrationName)-metrics.yml.sample"
+                      Source="$(var.BinariesPath)New Relic\newrelic-infra\integrations.d\$(var.IntegrationName)-metrics.yml.sample"
+                      KeyPath="yes"/>
+            </Component>
         </ComponentGroup>
     </Fragment>
 </Wix>

--- a/build/package/windows/nri-amd64-installer/Product.wxs
+++ b/build/package/windows/nri-amd64-installer/Product.wxs
@@ -93,6 +93,12 @@
                       Source="$(var.BinariesPath)New Relic\newrelic-infra\integrations.d\$(var.IntegrationName)-config.yml.sample"
                       KeyPath="yes"/>
             </Component>
+            <Component Id="CMP_NRI_$(var.IntegrationName)_METRICS_YML" Guid="afbe3a0f-e7ac-4be0-9f47-2e2121ae08ca" Win64="yes">
+                <File Id="FILE_NRI_$(var.IntegrationName)_METRICS_YML"
+                      Name="$(var.IntegrationName)-metrics.yml.sample"
+                      Source="$(var.BinariesPath)New Relic\newrelic-infra\integrations.d\$(var.IntegrationName)-metrics.yml.sample"
+                      KeyPath="yes"/>
+            </Component>
         </ComponentGroup>
     </Fragment>
 </Wix>

--- a/build/windows/fix_archives.sh
+++ b/build/windows/fix_archives.sh
@@ -29,6 +29,7 @@ find dist -regex ".*_dirty\.zip" | while read zip_dirty; do
   mv ${ZIP_CONTENT_PATH}/nri-${INTEGRATION}.exe "${AGENT_DIR_IN_ZIP_PATH}/bin"
   mv ${ZIP_CONTENT_PATH}/${INTEGRATION}-win-definition.yml "${AGENT_DIR_IN_ZIP_PATH}"
   mv ${ZIP_CONTENT_PATH}/${INTEGRATION}-config.yml.sample "${CONF_IN_ZIP_PATH}"
+  mv ${ZIP_CONTENT_PATH}/${INTEGRATION}-metrics.yml.sample "${CONF_IN_ZIP_PATH}"
 
   echo "===> Creating zip ${ZIP_CLEAN}"
   cd "${ZIP_CONTENT_PATH}"

--- a/snmp-config.yml.sample
+++ b/snmp-config.yml.sample
@@ -10,21 +10,17 @@ integration_name: com.newrelic.snmp
 
 instances:
   - name: <INSTANCE IDENTIFIER>
-    command: metrics
+    # gets metrics and inventory
+    command: all_data
     arguments:
       snmp_host: localhost
       snmp_port: 161
       community: public
-      collection_files: "/etc/newrelic-infra/integrations.d/snmp-metrics.yml"
-    labels:
-      key1: <LABEL_VALUE>
 
-  - name: <OTHER INSTANCE IDENTIFIER>
-    command: inventory
-    arguments:
-      snmp_host: localhost
-      snmp_port: 161
-      community: public
+      # path to the file containing metrics to be collected.
+      # Example:
+      # - linux: "/etc/newrelic-infra/integrations.d/snmp-metrics.yml"
+      # - windows: "c:\progra~1\newreli~1\newrelic-infra\integrations.d\snmp-metrics.yml"
       collection_files: "/etc/newrelic-infra/integrations.d/snmp-metrics.yml"
     labels:
       key1: <LABEL_VALUE>

--- a/snmp-definition.yml
+++ b/snmp-definition.yml
@@ -16,19 +16,4 @@ commands:
     command:
       - ./bin/nri-snmp
     interval: 30
-  metrics:
-    command:
-      - ./bin/nri-snmp
-      - --metrics
-    interval: 30
-  inventory:
-    command:
-      - ./bin/nri-snmp
-      - --inventory
     prefix: config/snmp
-    interval: 30
-  events:
-    command:
-    - ./bin/nri-snmp
-    - --events
-    interval: 30

--- a/snmp-win-definition.yml
+++ b/snmp-win-definition.yml
@@ -16,19 +16,4 @@ commands:
     command:
       - .\bin\nri-snmp.exe
     interval: 30
-  metrics:
-    command:
-      - .\bin\nri-snmp.exe
-      - --metrics
-    interval: 30
-  inventory:
-    command:
-      - .\bin\nri-snmp.exe
-      - --inventory
     prefix: config/snmp
-    interval: 30
-  events:
-    command:
-      - .\bin\nri-snmp.exe
-    - --events
-    interval: 30


### PR DESCRIPTION
This PR does 2 things:
- adds the sample metrics file to the packages, so that customer have an example of how to create one

- remove obsolete commands "metrics", "inventory" and "events" from the definition files. The integration DOES not use them in any way, and it always collects metrics and inventory. "events" is not even implemented, it's probably just some copy-paste error from some other integration
 