### PR TITLE
docs: added note about NPM

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,7 +20,7 @@ jobs:
     name: Run security checks via snyk
     runs-on: ubuntu-20.04
     env:
-      SNYK_TOKEN: ${{ secrets.COREINT_SNYK_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.CAOS_SNYK_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -37,7 +37,7 @@ jobs:
     name: Run security checks via snyk
     runs-on: ubuntu-20.04
     env:
-      SNYK_TOKEN: ${{ secrets.COREINT_SNYK_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.CAOS_SNYK_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
+>⚠️ We recommend using New Relic [Network Performance Monitoring](https://docs.newrelic.com/docs/network-performance-monitoring/) to collect both SNMP and Network Flows. This integration will be deprecated in favor of the new solution.  
+
 # New Relic Infrastructure integration for SNMP
 
 The New Relic integration for SNMP captures critical performance metrics and inventory reported by an SNMP server.


### PR DESCRIPTION
Added a note promoting the new NPM solution. 
nri-snmp should be deprecated later in 2022. 